### PR TITLE
fix(mongo-history): sorting the slice by parsing the time correctly

### DIFF
--- a/cmd/summary/nodes.go
+++ b/cmd/summary/nodes.go
@@ -4,18 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/Jacobbrewer1/puppet-summary/pkg/dataaccess"
+	"github.com/Jacobbrewer1/puppet-summary/pkg/entities"
+	"github.com/Jacobbrewer1/puppet-summary/pkg/logging"
+	"github.com/Jacobbrewer1/puppet-summary/pkg/request"
+	"github.com/gorilla/mux"
 	"html/template"
 	"io"
 	"log/slog"
 	"net/http"
 	"os"
 	"strconv"
-
-	"github.com/Jacobbrewer1/puppet-summary/pkg/dataaccess"
-	"github.com/Jacobbrewer1/puppet-summary/pkg/entities"
-	"github.com/Jacobbrewer1/puppet-summary/pkg/logging"
-	"github.com/Jacobbrewer1/puppet-summary/pkg/request"
-	"github.com/gorilla/mux"
 )
 
 func nodeFqdnHandler(w http.ResponseWriter, r *http.Request) {

--- a/cmd/summary/nodes.go
+++ b/cmd/summary/nodes.go
@@ -4,17 +4,18 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/Jacobbrewer1/puppet-summary/pkg/dataaccess"
-	"github.com/Jacobbrewer1/puppet-summary/pkg/entities"
-	"github.com/Jacobbrewer1/puppet-summary/pkg/logging"
-	"github.com/Jacobbrewer1/puppet-summary/pkg/request"
-	"github.com/gorilla/mux"
 	"html/template"
 	"io"
 	"log/slog"
 	"net/http"
 	"os"
 	"strconv"
+
+	"github.com/Jacobbrewer1/puppet-summary/pkg/dataaccess"
+	"github.com/Jacobbrewer1/puppet-summary/pkg/entities"
+	"github.com/Jacobbrewer1/puppet-summary/pkg/logging"
+	"github.com/Jacobbrewer1/puppet-summary/pkg/request"
+	"github.com/gorilla/mux"
 )
 
 func nodeFqdnHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/dataaccess/db_mongo.go
+++ b/pkg/dataaccess/db_mongo.go
@@ -139,12 +139,12 @@ func (m *mongodbImpl) GetHistory(ctx context.Context, environment entities.Envir
 	// Sort the dates in reverse order.
 	sort.Slice(dates, func(i, j int) bool {
 		// Parse the dates.
-		iDate, err := time.Parse(time.RFC3339, dates[i])
+		iDate, err := time.Parse(time.DateOnly, dates[i])
 		if err != nil {
 			slog.Error("Error parsing date", slog.String(logging.KeyError, err.Error()))
 			return false
 		}
-		jDate, err := time.Parse(time.RFC3339, dates[j])
+		jDate, err := time.Parse(time.DateOnly, dates[j])
 		if err != nil {
 			slog.Error("Error parsing date", slog.String(logging.KeyError, err.Error()))
 			return false


### PR DESCRIPTION
## Describe your changes

We found the following log line when retrieving the history for the index page

```json
{"time":"2023-12-20T20:56:14.566391852Z","level":"ERROR","source":"dataaccess/db_mongo.go 144","msg":"Error parsing date","app":"summary","err":"parsing time \"2023-12-19\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"\" as \"T\""}
```

This fixes the parsing time error.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] For new code, I have added tests that prove my fix is effective or that my feature works.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have implemented monitoring for my changes if applicable.
