### PR TITLE
fix(upload): Changing the secure flag to be a token that is compared with requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ using `SQLITE` and storing the YAML files on the local filesystem.
 This repo has been updated to use MySQL, MongoDB or SQLite as the database backend and also has the ability to upload
 the raw reports to Google Cloud Storage for further processing. This also allows for more than one instance of the
 application to be running at the same time. By allowing for MySQL or MongoDB as the database backend, this allows for
-for data retention on a more reliable database.
+data retention on a more reliable database.
 
 ## Usage
 
@@ -16,13 +16,12 @@ for data retention on a more reliable database.
 
 ```text
 Usage of ./puppet-summary:
-  -db string
+  -db <string>
         Database to use (default "sqlite"). Valid options are: sqlite, mysql, mongo.
   -gcs
         Enable Google Cloud Storage upload.
-  -secure-upload
-        Enable secure upload. This will prevent any requests to the /upload endpoint that have not been authenticated 
-        by the proxy.
+  -upload-token <string>
+        Enables secure upload. Requires a token to be specified. This is useful if you want to prevent any unauthorised requests to the /upload endpoint.
   -version
         Print version and exit.
 ```
@@ -80,10 +79,11 @@ GCS_BUCKET="puppet-reports"
 #### Secure Upload
 
 ```shell
-./puppet-summary -secure-upload
+./puppet-summary -upload-token <token>
 ```
 
-This will enable the `/upload` endpoint to only accept requests from within the cluster. This is done by checking the
-`Proxy-Authentication-Info` header to see if the request has come from within the cluster. This is useful if you are using
-something like Ambassador to expose the `/upload` endpoint to the internet. You would then use a proxy such as NGINX
-with authentication to allow access to the `/upload` endpoint.
+This will enable the `/upload` endpoint to only accept requests that have this Bearer token in the `Authorization`
+header. This is useful if you want to prevent any unauthorised requests to the `/upload` endpoint. One architecture
+pattern that you could use is to have a proxy in front of the Puppet Summary application that will handle the
+authentication and then forward the request to the Puppet Summary application with the Bearer token in the
+`Authorization` header.

--- a/cmd/summary/config.go
+++ b/cmd/summary/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log/slog"
 
 	"github.com/Jacobbrewer1/puppet-summary/pkg/dataaccess"
 )
@@ -22,6 +23,11 @@ func generateConfig() error {
 	err = dataaccess.ConnectGCS()
 	if err != nil {
 		return fmt.Errorf("error connecting to GCS: %w", err)
+	}
+	if *uploadToken != "" {
+		slog.Info("Upload token set, security on upload endpoint is enabled")
+	} else {
+		slog.Info("Upload token not set, upload endpoint is not secure")
 	}
 	return nil
 }

--- a/cmd/summary/config.go
+++ b/cmd/summary/config.go
@@ -12,7 +12,7 @@ const (
 	appName = "summary"
 )
 
-var secureUpload = flag.Bool("secure-upload", false, "Does not allow requests that have come from outside the cluster")
+var uploadToken = flag.String("upload-token", "", "The Bearer token used to authenticate requests to the upload endpoint.")
 
 func generateConfig() error {
 	err := dataaccess.ConnectDatabase()

--- a/pkg/messages/strings.go
+++ b/pkg/messages/strings.go
@@ -10,6 +10,9 @@ const (
 	// ErrDuplicate is the error message for duplicate.
 	ErrDuplicate = "Duplicate record"
 
+	// ErrUnauthorized is the error message for unauthorized.
+	ErrUnauthorized = "Unauthorized"
+
 	// ErrRequestAlreadyInProgress is the error message for already processing.
 	ErrRequestAlreadyInProgress = "A request is already being processed for this path"
 


### PR DESCRIPTION
## Describe your changes

Changing the `secureUpload` flag to be `upload-token` and take in a token to compare with the Bearer token on requests.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] For new code, I have added tests that prove my fix is effective or that my feature works.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have implemented monitoring for my changes if applicable.
