### PR TITLE
chore(db): Using a unified environment variable for the db connection string

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,20 +14,20 @@ data retention on a more reliable database.
 
 #### MySQL
 
-When using MySQL, you will be required to specify a `MYSQL_CONNECTION` environment variable with the connection string
+When using MySQL, you will be required to specify a `DB_CONN_STR` environment variable with the connection string
 to your MySQL database. For example:
 
 ```text
-MYSQL_CONNECTION="root:Password01@tcp(localhost:3306)/puppet-summary?timeout=90s&multiStatements=true&parseTime=true"
+DB_CONN_STR="root:Password01@tcp(localhost:3306)/puppet-summary?timeout=90s&multiStatements=true&parseTime=true"
 ```
 
 #### MongoDB
 
-When using MongoDB, you will be required to specify a `MONGO_URI` environment variable with the connection URI to your
+When using MongoDB, you will be required to specify a `DB_CONN_STR` environment variable with the connection URI to your
 MongoDB database. For example:
 
 ```text
-MONGO_URI="mongodb+srv://user:password@host/?retryWrites=true"
+DB_CONN_STR="mongodb+srv://user:password@host/?retryWrites=true"
 ```
 
 #### Google Cloud Storage

--- a/pkg/dataaccess/db.go
+++ b/pkg/dataaccess/db.go
@@ -8,6 +8,8 @@ import (
 	"github.com/Jacobbrewer1/puppet-summary/pkg/entities"
 )
 
+const envDbConnStr = "DB_CONN_STR"
+
 var DB Database
 
 type Database interface {

--- a/pkg/dataaccess/db_mongo.go
+++ b/pkg/dataaccess/db_mongo.go
@@ -17,12 +17,10 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-const EnvMongoURI = `MONGO_URI`
-
 const mongoDatabase = "puppet-summary"
 
 func connectMongoDB(ctx context.Context) {
-	connectionString := os.Getenv(EnvMongoURI)
+	connectionString := os.Getenv(envDbConnStr)
 	if connectionString != "" {
 		slog.Debug("Found MongoDB URI in environment")
 	} else {

--- a/pkg/dataaccess/db_mysql.go
+++ b/pkg/dataaccess/db_mysql.go
@@ -15,10 +15,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const EnvMySQLConnection = `MYSQL_CONNECTION`
-
 func connectMysql() {
-	connectionString := os.Getenv(EnvMySQLConnection)
+	connectionString := os.Getenv(envDbConnStr)
 	if connectionString != "" {
 		slog.Debug("Found MySQL URI in environment")
 	} else {


### PR DESCRIPTION
## Describe your changes

Changing the database environment variables for the connection string to be a unified name for all database types.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] For new code, I have added tests that prove my fix is effective or that my feature works.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] I have implemented monitoring for my changes if applicable.
