### PR TITLE
chore(logging): Making the invalid token logging more verbose

### DIFF
--- a/cmd/summary/upload.go
+++ b/cmd/summary/upload.go
@@ -18,7 +18,7 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 	if uploadToken != "" {
 		// Check the token.
 		if r.Header.Get("Authorization") != "Bearer "+uploadToken {
-			slog.Warn("Invalid token")
+			slog.Warn("Invalid upload token", slog.String("token", r.Header.Get("Authorization")))
 			w.WriteHeader(http.StatusUnauthorized)
 			if err := json.NewEncoder(w).Encode(request.NewMessage(messages.ErrUnauthorized)); err != nil {
 				slog.Error("Error encoding response", slog.String(logging.KeyError, err.Error()))


### PR DESCRIPTION
## Describe your changes

Adding more verbose logging around the upload endpoint. This includes things such as the token used and changing the warning message.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] For new code, I have added tests that prove my fix is effective or that my feature works.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have implemented monitoring for my changes if applicable.
