### PR TITLE
chore(auth): Changing the upload token to be an auth token

### DIFF
--- a/cmd/summary/config.go
+++ b/cmd/summary/config.go
@@ -12,7 +12,7 @@ const (
 )
 
 var (
-	uploadToken string
+	authToken string
 )
 
 func setupLogging() error {

--- a/cmd/summary/middleware.go
+++ b/cmd/summary/middleware.go
@@ -63,8 +63,17 @@ func middlewareHttp(handler Controller, authOption AuthOption) http.HandlerFunc 
 		}
 
 		switch authOption {
-		case AuthOptionNone, AuthOptionRequired:
+		case AuthOptionNone:
 		// Do nothing.
+		case AuthOptionRequired:
+			if authToken != "" {
+				// Check the token.
+				if r.Header.Get("Authorization") != "Bearer "+authToken {
+					slog.Warn("Invalid upload token", slog.String("token", r.Header.Get("Authorization")))
+					request.UnauthorizedHandler().ServeHTTP(w, r)
+					return
+				}
+			}
 		case AuthOptionInternal:
 			// Check if the request is internal.
 			if !request.IsInternal(r) {

--- a/cmd/summary/upload.go
+++ b/cmd/summary/upload.go
@@ -15,15 +15,6 @@ import (
 
 // uploadHandler takes the uploaded file and stores it in the database.
 func uploadHandler(w http.ResponseWriter, r *http.Request) {
-	if uploadToken != "" {
-		// Check the token.
-		if r.Header.Get("Authorization") != "Bearer "+uploadToken {
-			slog.Warn("Invalid upload token", slog.String("token", r.Header.Get("Authorization")))
-			request.UnauthorizedHandler().ServeHTTP(w, r)
-			return
-		}
-	}
-
 	if r.Body == http.NoBody {
 		slog.Warn("Request body is empty")
 		w.WriteHeader(http.StatusBadRequest)


### PR DESCRIPTION
## Describe your changes

Renaming the upload token to be the authentication token and applying the logic to all endpoints using `AuthOptionRequired`.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] For new code, I have added tests that prove my fix is effective or that my feature works.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have implemented monitoring for my changes if applicable.
