### PR TITLE
fix(responses): Using the generated responses rather than the local objects

### DIFF
--- a/pkg/codegen/apis/summary/routes.yaml
+++ b/pkg/codegen/apis/summary/routes.yaml
@@ -163,11 +163,16 @@ paths:
             type: string
       responses:
         '200':
-          description: Get a node by fqdn
+          description: Get reports by fqdn
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/node'
+                type: object
+                properties:
+                  nodes:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/puppetReportSummary'
         '400':
           description: Bad request
           content:
@@ -256,6 +261,33 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Resource'
+
+    puppetReportSummary:
+      type: object
+      properties:
+        id:
+          type: string
+        fqdn:
+          type: string
+        env:
+          $ref: '#/components/schemas/environment'
+        state:
+          $ref: '#/components/schemas/state'
+        exec_time:
+          type: string
+          format: date-time
+          example: '2024-02-13T10:00:09Z'
+        runtime:
+          type: string
+          example: 23s
+        failed:
+          type: integer
+        changed:
+          type: integer
+        skipped:
+          type: integer
+        total:
+          type: integer
 
     Resource:
       type: object

--- a/pkg/codegen/apis/summary/types.go
+++ b/pkg/codegen/apis/summary/types.go
@@ -94,6 +94,24 @@ type PuppetReport struct {
 	Total *int   `json:"total,omitempty"`
 }
 
+// PuppetReportSummary defines the model for puppetReportSummary.
+type PuppetReportSummary struct {
+	Changed *int `json:"changed,omitempty"`
+
+	// Env The environment that a machine is reporting from.
+	Env      *Environment `json:"env,omitempty"`
+	ExecTime *time.Time   `json:"exec_time,omitempty"`
+	Failed   *int         `json:"failed,omitempty"`
+	Fqdn     *string      `json:"fqdn,omitempty"`
+	Id       *string      `json:"id,omitempty"`
+	Runtime  *string      `json:"runtime,omitempty"`
+	Skipped  *int         `json:"skipped,omitempty"`
+
+	// State The estate of the machine from the report.
+	State *State `json:"state,omitempty"`
+	Total *int   `json:"total,omitempty"`
+}
+
 // State defines the model for state.
 type State string
 

--- a/pkg/entities/report.go
+++ b/pkg/entities/report.go
@@ -46,7 +46,7 @@ type PuppetReportSummary struct {
 	Total int `json:"total" bson:"total"`
 
 	// YamlFile is the file the report was read from.
-	YamlFile string `json:"yamlFile" bson:"yamlFile"`
+	YamlFile string `json:"-" bson:"yamlFile"`
 }
 
 func (n *PuppetReportSummary) CalculateTimeSince() {

--- a/pkg/services/api/nodes.go
+++ b/pkg/services/api/nodes.go
@@ -101,7 +101,7 @@ func (s service) GetAllNodes(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("content-type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(nodes); err != nil {
+	if err := json.NewEncoder(w).Encode(mappedNodes); err != nil {
 		slog.Warn("Error encoding response", slog.String(logging.KeyError, err.Error()))
 	}
 }
@@ -194,7 +194,7 @@ func (s service) GetAllNodesByEnvironment(w http.ResponseWriter, r *http.Request
 
 	w.Header().Set("content-type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(nodes); err != nil {
+	if err := json.NewEncoder(w).Encode(mappedNodes); err != nil {
 		slog.Warn("Error encoding response", slog.String(logging.KeyError, err.Error()))
 	}
 }
@@ -224,9 +224,25 @@ func (s service) GetNodeByFqdn(w http.ResponseWriter, r *http.Request, fqdn stri
 		return reps[i].ExecTime.Time().Before(reps[j].ExecTime.Time())
 	})
 
+	resp := make([]*summary.PuppetReportSummary, 0, len(reps))
+	for _, rep := range reps {
+		resp = append(resp, &summary.PuppetReportSummary{
+			Changed:  &rep.Changed,
+			Env:      &rep.Env,
+			ExecTime: summary.Point(rep.ExecTime.Time()),
+			Failed:   &rep.Failed,
+			Fqdn:     &rep.Fqdn,
+			Id:       &rep.ID,
+			Runtime:  summary.Point(rep.Runtime.String()),
+			Skipped:  &rep.Skipped,
+			State:    &rep.State,
+			Total:    &rep.Total,
+		})
+	}
+
 	w.Header().Set("content-type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(reps); err != nil {
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		slog.Warn("Error encoding response", slog.String(logging.KeyError, err.Error()))
 	}
 }

--- a/pkg/services/api/nodes_test.go
+++ b/pkg/services/api/nodes_test.go
@@ -52,14 +52,14 @@ func (s *GetAllNodesSuite) TestGetAllNodes() {
 		{
 			Fqdn:     "test2",
 			Env:      summary.Environment_STAGING,
-			ExecTime: entities.Datetime(now),
+			ExecTime: entities.Datetime(now.Add(10 * time.Second)),
 			Runtime:  entities.Duration(10 * time.Second),
 			State:    summary.State_UNCHANGED,
 		},
 		{
 			Fqdn:     "test3",
 			Env:      summary.Environment_DEVELOPMENT,
-			ExecTime: entities.Datetime(now),
+			ExecTime: entities.Datetime(now.Add(20 * time.Second)),
 			Runtime:  entities.Duration(10 * time.Second),
 			State:    summary.State_CHANGED,
 		},
@@ -78,7 +78,7 @@ func (s *GetAllNodesSuite) TestGetAllNodes() {
 	s.Equal("application/json", w.Header().Get("Content-Type"))
 
 	// Compare the response.
-	expected := "[{\"env\":\"PRODUCTION\",\"exec_time\":\"" + now.Format(time.RFC3339) + "\",\"fqdn\":\"test1\",\"runtime\":\"10s\",\"state\":\"SKIPPED\"},{\"env\":\"STAGING\",\"exec_time\":\"" + now.Format(time.RFC3339) + "\",\"fqdn\":\"test2\",\"runtime\":\"10s\",\"state\":\"UNCHANGED\"},{\"env\":\"DEVELOPMENT\",\"exec_time\":\"" + now.Format(time.RFC3339) + "\",\"fqdn\":\"test3\",\"runtime\":\"10s\",\"state\":\"CHANGED\"}]\n"
+	expected := "[{\"env\":\"PRODUCTION\",\"exec_time\":\"" + now.Format(time.RFC3339) + "\",\"fqdn\":\"test1\",\"runtime\":\"10s\",\"state\":\"SKIPPED\"},{\"env\":\"STAGING\",\"exec_time\":\"" + now.Add(10*time.Second).Format(time.RFC3339) + "\",\"fqdn\":\"test2\",\"runtime\":\"10s\",\"state\":\"UNCHANGED\"},{\"env\":\"DEVELOPMENT\",\"exec_time\":\"" + now.Add(20*time.Second).Format(time.RFC3339) + "\",\"fqdn\":\"test3\",\"runtime\":\"10s\",\"state\":\"CHANGED\"}]\n"
 	s.Require().Equal(expected, w.Body.String())
 
 	s.db.AssertExpectations(s.T())

--- a/pkg/services/api/nodes_test.go
+++ b/pkg/services/api/nodes_test.go
@@ -47,18 +47,21 @@ func (s *GetAllNodesSuite) TestGetAllNodes() {
 			Env:      summary.Environment_PRODUCTION,
 			ExecTime: entities.Datetime(now),
 			Runtime:  entities.Duration(10 * time.Second),
+			State:    summary.State_SKIPPED,
 		},
 		{
 			Fqdn:     "test2",
 			Env:      summary.Environment_STAGING,
 			ExecTime: entities.Datetime(now),
 			Runtime:  entities.Duration(10 * time.Second),
+			State:    summary.State_UNCHANGED,
 		},
 		{
 			Fqdn:     "test3",
-			Env:      summary.Environment_PRODUCTION,
+			Env:      summary.Environment_DEVELOPMENT,
 			ExecTime: entities.Datetime(now),
 			Runtime:  entities.Duration(10 * time.Second),
+			State:    summary.State_CHANGED,
 		},
 	}
 
@@ -75,7 +78,7 @@ func (s *GetAllNodesSuite) TestGetAllNodes() {
 	s.Equal("application/json", w.Header().Get("Content-Type"))
 
 	// Compare the response.
-	expected := "[{\"fqdn\":\"test1\",\"env\":\"PRODUCTION\",\"state\":\"\",\"exec_time\":\"" + now.Format(time.RFC3339) + "\",\"runtime\":\"10s\"},{\"fqdn\":\"test2\",\"env\":\"STAGING\",\"state\":\"\",\"exec_time\":\"" + now.Format(time.RFC3339) + "\",\"runtime\":\"10s\"},{\"fqdn\":\"test3\",\"env\":\"PRODUCTION\",\"state\":\"\",\"exec_time\":\"" + now.Format(time.RFC3339) + "\",\"runtime\":\"10s\"}]\n"
+	expected := "[{\"env\":\"PRODUCTION\",\"exec_time\":\"" + now.Format(time.RFC3339) + "\",\"fqdn\":\"test1\",\"runtime\":\"10s\",\"state\":\"SKIPPED\"},{\"env\":\"STAGING\",\"exec_time\":\"" + now.Format(time.RFC3339) + "\",\"fqdn\":\"test2\",\"runtime\":\"10s\",\"state\":\"UNCHANGED\"},{\"env\":\"DEVELOPMENT\",\"exec_time\":\"" + now.Format(time.RFC3339) + "\",\"fqdn\":\"test3\",\"runtime\":\"10s\",\"state\":\"CHANGED\"}]\n"
 	s.Require().Equal(expected, w.Body.String())
 
 	s.db.AssertExpectations(s.T())


### PR DESCRIPTION
## Describe your changes

Using the generated responses rather than the local objects for the responses to the API.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] For new code, I have added tests that prove my fix is effective or that my feature works.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have implemented monitoring for my changes if applicable.
